### PR TITLE
Check for undefined value

### DIFF
--- a/lib/Where.js
+++ b/lib/Where.js
@@ -35,7 +35,7 @@ function buildOrGroup(Dialect, where) {
 			continue;
 		}
 		for (var k in where[i].w) {
-			if (where[i].w[k] === null) {
+			if (!where[i].w[k]) {
 				query.push(
 					buildComparisonKey(Dialect, where[i].t, k) +
 					" IS NULL"


### PR DESCRIPTION
If where[i].w[k] is tested for null and not also undefined then 
when saving a Model in Node-Orm2 that has a hasMany relationship defined the 
save crashes.
