### PR TITLE
Support for custom types via function

### DIFF
--- a/lib/Dialects/mysql.js
+++ b/lib/Dialects/mysql.js
@@ -41,6 +41,10 @@ exports.escapeVal = function (val, timeZone) {
 		return objectToValues(val, timeZone || "Z");
 	}
 
+  if (typeof val === 'function') {
+    return val();
+  }
+
 	val = val.replace(/[\0\n\r\b\t\\\'\"\x1a]/g, function(s) {
 		switch(s) {
 			case "\0": return "\\0";


### PR DESCRIPTION
Adding support for custom value types emitting their value via a function. This seemed the easiest path to supporting things like MySQL Spatial extension types (in my case I need POINT) or other custom data types.
