### PR TITLE
Support for multiple joins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.sublime-*
+*.njsproj
 .DS_Store
 node_modules
 test.js

--- a/lib/Select.js
+++ b/lib/Select.js
@@ -102,11 +102,28 @@ function SelectQuery(Dialect) {
 				return this;
 			}
 
+			var a, f = from_id, t;
 			if (arguments.length == 3) {
-				from.j = [ from_id, sql.from[sql.from.length - 1].a, to_table ];
+			    a = sql.from[sql.from.length - 1].a;
+			    t = to_table;
 			} else {
-				from.j = [ from_id, get_table_alias(to_table), to_id ];
+			    a = get_table_alias(to_table);
+			    t = to_id;
 			}
+
+			from.j = [];
+			if (f.length && t.length) {
+			    if (Array.isArray(f) && Array.isArray(t) && f.length == t.length) {
+			        for (i = 0; i < f.length; i++) {
+			            from.j.push([f[i], a, t[i]]);
+			        }
+			    } else {
+			        from.j.push([f, a, t]);
+			    }
+			} else {
+			    throw new Error();
+			}
+
 			sql.from.push(from);
 			return this;
 		},
@@ -294,15 +311,21 @@ function SelectQuery(Dialect) {
 						query.push(Dialect.escapeId(sql.from[i].t) + " " + Dialect.escapeId(sql.from[i].a));
 					}
 					if (i > 0) {
-						query.push(
-							"ON " +
-							Dialect.escapeId(sql.from[i].a, sql.from[i].j[0]) +
-							" = " +
-							Dialect.escapeId(sql.from[i].j[1], sql.from[i].j[2])
-						);
+					    query.push("ON");
+                        
+					    for (ii = 0; ii < sql.from[i].j.length; ii++) {
+					        if (ii > 0) {
+					            query.push("AND");
+					        }
+					        query.push(
+                                Dialect.escapeId(sql.from[i].a, sql.from[i].j[ii][0]) +
+                                " = " +
+                                Dialect.escapeId(sql.from[i].j[ii][1], sql.from[i].j[ii][2])
+                                );
+					    }
 
 						if (i < sql.from.length - 1) {
-							query.push(")");
+						    query.push(")");
 						}
 					}
 				}

--- a/test/integration/test-select.js
+++ b/test/integration/test-select.js
@@ -93,3 +93,9 @@ assert.equal(
 	               .from('table2', 'id2', 'table1', 'id1').fun('AVG', 'col').build(),
 	"SELECT AVG(`t2`.`col`) FROM `table1` `t1` JOIN `table2` `t2` ON `t2`.`id2` = `t1`.`id1`"
 );
+
+assert.equal(
+    common.Select().from('table1')
+                   .from('table2',['id2a', 'id2b'], 'table1', ['id1a', 'id1b']).count('id').build(),
+    "SELECT COUNT(`t2`.`id`) FROM `table1` `t1` JOIN `table2` `t2` ON `t2`.`id2a` = `t1`.`id1a` AND `t2`.`id2b` = `t1`.`id1b`"
+);


### PR DESCRIPTION
Allows you to execute joins on records which match a number of values between the tables. This functionality is implemented in a backwards compatible manner to prevent breaking node-orm2, pending changes on that branch which make use of this functionality.

This allows queries like the following to be generated

``` sql
SELECT * FROM `table1` `t1` JOIN `table2` `t2` ON `t1`.`id1` = `t2`.`id1` AND `t1`.`id2` = `t2`.`id2`
```

This change is necessary to allow the implementation of support for multiple primary keys on models in node-orm2, something I'm currently working on finishing in [SPARTAN563/node-orm2:smart_associations](/SPARTAN563/node-orm2/tree/smart_associations)
