### PR TITLE
Store all dates as UTC for SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.sublime-*
 *.njsproj
+.idea
 .DS_Store
 node_modules
 test.js

--- a/lib/Helpers.js
+++ b/lib/Helpers.js
@@ -18,6 +18,10 @@ module.exports.escapeQuery = function (Dialect, query, args) {
 module.exports.dateToString = function (date, timeZone, opts) {
   var dt = new Date(date);
 
+  if (opts.dialect === 'sqlite') {
+    return dt.toISOString();
+  }
+
   if (timeZone != 'local') {
     var tz = convertTimezone(timeZone);
 

--- a/test/integration/test-dialect-sqlite.js
+++ b/test/integration/test-dialect-sqlite.js
@@ -71,7 +71,7 @@ assert.equal(
 
 assert.equal(
 	dialect.escapeVal(new Date(d.getTime() + tzOffsetMillis)),
-	"'2013-09-04T19:15:11.133Z'"
+	"'" + new Date(d.getTime() + tzOffsetMillis).toISOString() + "'"
 );
 
 assert.equal(
@@ -86,7 +86,7 @@ assert.equal(
 
 assert.equal(
 	dialect.escapeVal(new Date(d.getTime()), '-0400'),
-	"'2013-09-04T15:15:11.133Z'"
+	"'2013-09-04T19:15:11.133Z'"
 );
 
 assert.equal(


### PR DESCRIPTION
Dates are stored in SQLite as Unix timestamps. Dates are represented in JavaScript as Unix timestamps. Thus, there need not be any sort of conversions. Client-side timezones are irrelevant; they should only affect the client-side display of dates. The existing code is incorrect because it's storing timezone-offset dates _as UTC dates_ (with the "Z" suffix).

This change simplifies the type conversion; a Date is stored as an ISO-8601 date string, which is understood by both JavaScript's `Date` constructor and SQLite.
