### PR TITLE
Add check for object escaping

### DIFF
--- a/lib/Dialects/postgresql.js
+++ b/lib/Dialects/postgresql.js
@@ -6,13 +6,14 @@ exports.DataTypes = {
     int: 'INTEGER',
     float: 'REAL',
     bool: 'SMALLINT',
-    text: 'TEXT'
+    text: 'TEXT',
+    json: 'JSON'
 };
 
 
 exports.escape = function (query, args) {
 	return helpers.escapeQuery(exports, query, args);
-}
+};
 
 exports.escapeId = function () {
 	return Array.prototype.slice.apply(arguments).map(function (el) {
@@ -60,6 +61,9 @@ exports.escapeVal = function (val, timeZone) {
 			return val ? "true" : "false";
 		case "function":
 			return val(exports);
+		case "object":
+			val = JSON.stringify(val);
+			break;
 	}
 	// No need to escape backslashes with default PostgreSQL 9.1+ config.
 	// Google 'postgresql standard_conforming_strings' for details.

--- a/lib/Dialects/postgresql.js
+++ b/lib/Dialects/postgresql.js
@@ -7,7 +7,8 @@ exports.DataTypes = {
     float: 'REAL',
     bool: 'SMALLINT',
     text: 'TEXT',
-    json: 'JSON'
+    json: 'JSON',
+    jsonb: 'JSONB'
 };
 
 

--- a/test/integration/test-dialect-postgresql.js
+++ b/test/integration/test-dialect-postgresql.js
@@ -75,6 +75,11 @@ assert.equal(
 );
 
 assert.equal(
+	dialect.escapeVal({hello:'world', loneliest: { number: 1 }}),
+	'\'{"hello":"world","loneliest":{"number":1}}\''
+);
+
+assert.equal(
 	dialect.escapeVal(new Date(d.getTime() + tzOffsetMillis)),
 	"'2013-09-04T19:15:11.133Z'"
 );


### PR DESCRIPTION
Previously, an unspecified error was thrown using node-orm if an object was used with `db.models.*model*.create(*Object*, function(err, data){...`

This will allow objects to be created without needing to be `JSON.stringify`'d first. 

Also added `JSON` type so it doesn't need to be created as a custom type.