### PR TITLE
Add support for SELECT TOP construct for mssql dialect for limit

### DIFF
--- a/lib/Dialects/mssql.js
+++ b/lib/Dialects/mssql.js
@@ -66,3 +66,5 @@ exports.escapeVal = function (val, timeZone) {
 };
 
 exports.defaultValuesStmt = "DEFAULT VALUES";
+
+exports.limitAsTop = true;

--- a/lib/Remove.js
+++ b/lib/Remove.js
@@ -25,7 +25,12 @@ function RemoveQuery(Dialect, opts) {
 		build: function () {
 			var query = [], tmp;
 
-			query.push("DELETE FROM");
+			// limit as: SELECT TOP n (MSSQL only)
+			if (Dialect.limitAsTop && sql.hasOwnProperty("limit")) {
+				query.push("DELETE TOP " + sql.limit + " FROM");
+			} else {
+				query.push("DELETE FROM");
+			}
 			query.push(Dialect.escapeId(sql.table));
 
 			query = query.concat(Where.build(Dialect, sql.where, opts));
@@ -46,15 +51,17 @@ function RemoveQuery(Dialect, opts) {
 				}
 			}
 
-			// limit
-			if (sql.hasOwnProperty("limit")) {
-				if (sql.hasOwnProperty("offset")) {
-					query.push("LIMIT " + sql.limit + " OFFSET " + sql.offset);
-				} else {
-					query.push("LIMIT " + sql.limit);
+			// limit for all Dialects but MSSQL
+			if (!Dialect.limitAsTop) {
+				if (sql.hasOwnProperty("limit")) {
+					if (sql.hasOwnProperty("offset")) {
+						query.push("LIMIT " + sql.limit + " OFFSET " + sql.offset);
+					} else {
+						query.push("LIMIT " + sql.limit);
+					}
+				} else if (sql.hasOwnProperty("offset")) {
+					query.push("OFFSET " + sql.offset);
 				}
-			} else if (sql.hasOwnProperty("offset")) {
-				query.push("OFFSET " + sql.offset);
 			}
 
 			return query.join(" ");

--- a/lib/Select.js
+++ b/lib/Select.js
@@ -210,6 +210,11 @@ function SelectQuery(Dialect, opts) {
 
 			query.push("SELECT");
 
+			// limit as: SELECT TOP n (MSSQL only)
+			if (Dialect.limitAsTop && sql.hasOwnProperty("limit")) {
+				query.push("TOP " + sql.limit);
+			}
+
 			for (i = 0; i < sql.from.length; i++) {
 				sql.from[i].a = "t" + (i + 1);
 			}
@@ -399,15 +404,17 @@ function SelectQuery(Dialect, opts) {
 				}
 			}
 
-			// limit
-			if (sql.hasOwnProperty("limit")) {
-				if (sql.hasOwnProperty("offset")) {
-					query.push("LIMIT " + sql.limit + " OFFSET " + sql.offset);
-				} else {
-					query.push("LIMIT " + sql.limit);
+			// limit for all Dialects but MSSQL
+			if (!Dialect.limitAsTop) {
+				if (sql.hasOwnProperty("limit")) {
+					if (sql.hasOwnProperty("offset")) {
+						query.push("LIMIT " + sql.limit + " OFFSET " + sql.offset);
+					} else {
+						query.push("LIMIT " + sql.limit);
+					}
+				} else if (sql.hasOwnProperty("offset")) {
+					query.push("OFFSET " + sql.offset);
 				}
-			} else if (sql.hasOwnProperty("offset")) {
-				query.push("OFFSET " + sql.offset);
 			}
 
 			return query.join(" ");

--- a/test/integration/test-dialect-mssql.js
+++ b/test/integration/test-dialect-mssql.js
@@ -98,3 +98,9 @@ assert.equal(
   dialect.defaultValuesStmt,
   "DEFAULT VALUES"
 );
+
+//Assert that mssql is configured to use the SELECT TOP as a contruct for limit
+assert.equal(
+  dialect.limitAsTop,
+  true
+);

--- a/test/integration/test-dialect-mysql.js
+++ b/test/integration/test-dialect-mysql.js
@@ -98,3 +98,9 @@ assert.equal(
 	dialect.defaultValuesStmt,
 	"VALUES()"
 );
+
+//For all dialects but mssql limitAsTop should be undefined or false
+assert.equal(
+  dialect.limitAsTop || false,
+  false
+);

--- a/test/integration/test-dialect-postgresql.js
+++ b/test/integration/test-dialect-postgresql.js
@@ -103,3 +103,9 @@ assert.equal(
 	dialect.defaultValuesStmt,
 	"DEFAULT VALUES"
 );
+
+//For all dialects but mssql limitAsTop should be undefined or false
+assert.equal(
+  dialect.limitAsTop || false,
+  false
+);

--- a/test/integration/test-dialect-sqlite.js
+++ b/test/integration/test-dialect-sqlite.js
@@ -98,3 +98,9 @@ assert.equal(
 	dialect.defaultValuesStmt,
 	"DEFAULT VALUES"
 );
+
+//For all dialects but mssql limitAsTop should be undefined or false
+assert.equal(
+  dialect.limitAsTop || false,
+  false
+);


### PR DESCRIPTION
MSSQL is the only dialect supported by node-sql-query that constructs a limit as

    SELECT TOP [n rows] columns
    FROM tablename
    ORDER BY key ASC

instead of

    SELECT columns
    FROM tablename
    ORDER BY key ASC
    LIMIT n

This commit adds support for mssql and the limit property.