### PR TITLE
Support for json column type

### DIFF
--- a/lib/Dialects/postgresql.js
+++ b/lib/Dialects/postgresql.js
@@ -35,12 +35,12 @@ exports.escapeVal = function (val, timeZone) {
 	}
 
 	if (Array.isArray(val)){
-		// Stringiy json arrays (e.g. [{foo: 1}, {zed: 2}]). Enables using postgres json column type.
+		
+		// Stringify json arrays (e.g. [ {foo: 1}, {bar: 2}] )
 		var isJsonArray = true;
 		val.forEach(function(el){
-			if(typeof el !== "object"){
+			if(el.constructor !== {}.constructor) // = not an an json object
 				isJsonArray = false
-			}
 		})
 		if(isJsonArray)
 			return "'" + JSON.stringify(val) + "'";
@@ -57,6 +57,10 @@ exports.escapeVal = function (val, timeZone) {
 
 	if (Buffer.isBuffer(val)) {
 		return "'\\x" + val.toString("hex") + "'";
+	}
+
+	if (val.constructor === {}.constructor){  // json object
+		return "'" + JSON.stringify(val) + "'";
 	}
 
 	switch (typeof val) {

--- a/lib/Dialects/postgresql.js
+++ b/lib/Dialects/postgresql.js
@@ -34,7 +34,17 @@ exports.escapeVal = function (val, timeZone) {
 		return 'NULL';
 	}
 
-	if (Array.isArray(val)) {
+	if (Array.isArray(val)){
+		// Stringiy json arrays (e.g. [{foo: 1}, {zed: 2}]). Enables using postgres json column type.
+		var isJsonArray = true;
+		val.forEach(function(el){
+			if(typeof el !== "object"){
+				isJsonArray = false
+			}
+		})
+		if(isJsonArray)
+			return "'" + JSON.stringify(val) + "'";
+
 		if (val.length === 1 && Array.isArray(val[0])) {
 			return "(" + val[0].map(exports.escapeVal.bind(this)) + ")";
 		}

--- a/test/integration/test-dialect-postgresql.js
+++ b/test/integration/test-dialect-postgresql.js
@@ -65,6 +65,11 @@ assert.equal(
 );
 
 assert.equal(
+	dialect.escapeVal([ {'foo':123}, {bar:"json"}, {"zed":[1,5] }]),
+	'\'[{"foo":123},{"bar":"json"},{"zed":[1,5]}]\''
+);
+
+assert.equal(
 	dialect.escapeVal(true),
 	"true"
 );

--- a/test/integration/test-dialect-postgresql.js
+++ b/test/integration/test-dialect-postgresql.js
@@ -65,6 +65,11 @@ assert.equal(
 );
 
 assert.equal(
+	dialect.escapeVal({foo:1, foo:'1', 'bar':"a", "bar":"a"}),
+	'\'{"foo":"1","bar":"a"}\''
+);
+
+assert.equal(
 	dialect.escapeVal([ {'foo':123}, {bar:"json"}, {"zed":[1,5] }]),
 	'\'[{"foo":123},{"bar":"json"},{"zed":[1,5]}]\''
 );


### PR DESCRIPTION
Adds support for postgres json column type. 

Implemented in this way: 

`escapeVal()` checks if `val` is an json object (by using val.constructor === {}.constructor). If so, the `val` is stringified with JSON.stringify, then postgres will happily accept the value.

Json arrays (e.g.: `[ {foo:123}, {bar:456} ]`) are also supported, in this case the check is made for every array element, if they are all json objects, the array is stringified. 

Tests are provided.

This should also solve #43 
