### PR TITLE
add support to unescaped data

### DIFF
--- a/lib/Dialects/mysql.js
+++ b/lib/Dialects/mysql.js
@@ -33,6 +33,10 @@ exports.escapeVal = function (val, timeZone) {
 	if (val === undefined || val === null) {
 		return 'NULL';
 	}
+	
+	if( val instanceof NoEscape ) {
+		return val.getUnescapedParam();
+	}
 
 	if (Buffer.isBuffer(val)) {
 		return bufferToString(val);

--- a/lib/NoEscape.js
+++ b/lib/NoEscape.js
@@ -1,0 +1,13 @@
+/**
+ * To avoid escaping data
+ */
+module.exports = NoEscape;
+
+function NoEscape(param) {
+    
+    this.unescapedParameter = param;
+}
+
+NoEscape.prototype.getUnescapedParam = function() {
+    return this.unescapedParameter;
+}

--- a/lib/Query.js
+++ b/lib/Query.js
@@ -5,10 +5,12 @@ var UpdateQuery = require("./Update").UpdateQuery;
 var RemoveQuery = require("./Remove").RemoveQuery;
 var Comparators = require("./Comparators");
 var Helpers     = require('./Helpers');
+var NoEscape    = require( './NoEscape' );
 
 exports.Query = Query;
 exports.Comparators = Object.keys(Comparators);
 exports.Text = buildQueryType("text");
+exports.NoEscape = NoEscape;
 
 for (var comparator in Comparators) {
 	exports[comparator] = Comparators[comparator];


### PR DESCRIPTION
Can be used like so

var NoEscape   = require("sql-query").NoEscape;
var location = new NoEscape('ST_GeomFromText("POINT(30.062629699707 31.249670028687)")');
query = app.db.driver.execQuery(
            'INSERT INTO users(location)  VALUES(?)',
            [ location  ],
            function( err, data ) {
                    // do something
            }
        );
