### PR TITLE
BUG-MissingAlias in FROM

### DIFF
--- a/lib/Select.js
+++ b/lib/Select.js
@@ -338,11 +338,7 @@ function SelectQuery(Dialect, opts) {
 						}
 						query.push("JOIN");
 					}
-					if (sql.from.length == 1 && !sql.where_exists) {
-						query.push(Dialect.escapeId(from.t));
-					} else {
-						query.push(Dialect.escapeId(from.t) + " " + Dialect.escapeId(from.a));
-					}
+					query.push(Dialect.escapeId(from.t) + " " + Dialect.escapeId(from.a));
 					if (i > 0) {
 						query.push("ON");
 


### PR DESCRIPTION
- using the `.where(<tableName>, { <field>: <value> })` function on a simple select causes a bug because the alias definition is missing on the FROM but does exist on the WHERE.  There is no harm in having the alias being defined on a FROM on a simple query but is required on WHERE clauses in certain situations