### PR TITLE
Bug missing alias

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+### v0.1.26 - 16 May 2015
+
+- Add support for SELECT TOP construct for mssql dialect for limit (#41)
+
 ### v0.1.25 - 22 Mar 2015
 
 - Added support for left/right joins (#22)

--- a/lib/Select.js
+++ b/lib/Select.js
@@ -338,11 +338,7 @@ function SelectQuery(Dialect, opts) {
 						}
 						query.push("JOIN");
 					}
-					if (sql.from.length == 1 && !sql.where_exists) {
-						query.push(Dialect.escapeId(from.t));
-					} else {
-						query.push(Dialect.escapeId(from.t) + " " + Dialect.escapeId(from.a));
-					}
+					query.push(Dialect.escapeId(from.t) + " " + Dialect.escapeId(from.a));
 					if (i > 0) {
 						query.push("ON");
 

--- a/lib/Select.js
+++ b/lib/Select.js
@@ -150,6 +150,7 @@ function SelectQuery(Dialect, opts) {
 						t: get_table_alias(arguments[i]),
 						w: arguments[i + 1]
 					};
+					sql.where_exists = true;
 					i++;
 				} else {
 					if (where !== null) {
@@ -304,7 +305,7 @@ function SelectQuery(Dialect, opts) {
 
 					if (sql.from[i].select[j].s && sql.from[i].select[j].s.length > 0) {
 						str = sql.from[i].select[j].s.join("(") + "(" + str +
-						      ((new Array(sql.from[i].select[j].s.length + 1)).join(")"));
+							((new Array(sql.from[i].select[j].s.length + 1)).join(")"));
 					}
 
 					tmp.push(str);
@@ -338,7 +339,11 @@ function SelectQuery(Dialect, opts) {
 						}
 						query.push("JOIN");
 					}
-					query.push(Dialect.escapeId(from.t) + " " + Dialect.escapeId(from.a));
+					if (sql.from.length == 1 && !sql.where_exists) {
+						query.push(Dialect.escapeId(from.t));
+					} else {
+						query.push(Dialect.escapeId(from.t) + " " + Dialect.escapeId(from.a));
+					}
 					if (i > 0) {
 						query.push("ON");
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"sql",
 		"query"
   	],
-	"version": "0.1.25",
+	"version": "0.1.26",
 	"license": "MIT",
 	"repository": {
 		"url": "http://github.com/dresende/node-sql-query"


### PR DESCRIPTION
BUG-MissingAlias in FROM
- using the `.where(<tableName>, { <field>: <value> })` function on a simple select causes a bug because the alias definition is missing on the FROM but does exist on the WHERE.  This error is caused when utilizing the <tableName> parameter.